### PR TITLE
Update 01_ncbi_get_structural.py

### DIFF
--- a/model_training/01_ncbi_get_structural.py
+++ b/model_training/01_ncbi_get_structural.py
@@ -21,6 +21,7 @@
 # %%
 import os
 import sys
+import time
 sys.path.append("..")
 import phage_init
 


### PR DESCRIPTION
This import is needed to prevent `time.sleep(15)` in the HTTPError handler from crashing the download